### PR TITLE
Find a way to type hint loguru.Logger so that both Mypy and Python 3

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,8 @@ from eth_typing.bls import BLSPubkey
 from eth_typing.evm import HexAddress
 from google.protobuf import empty_pb2
 from grpc import insecure_channel, RpcError, StatusCode
-from loguru import logger, Logger
+import loguru
+from loguru import logger
 from notifiers.core import get_notifier  # type: ignore
 from web3 import Web3
 from web3.contract import Contract
@@ -206,7 +207,7 @@ def wait_prysm_ready(
     interrupt_handler: InterruptHandler,
     endpoint: str,
     process_interval: int,
-    logger: Logger,
+    logger: "loguru.Logger",
 ) -> None:
     """Wait that Prysm accepts requests and is synced.
 


### PR DESCRIPTION
We need to use string annotation, as otherwise Python run-time crashes on the annotation.

This is because loguru supplies its custom mypy type hints. 