### PR TITLE
Nethermind gnosis.cfg change

### DIFF
--- a/deploy/gnosis/docker-compose.yml
+++ b/deploy/gnosis/docker-compose.yml
@@ -119,10 +119,10 @@ services:
 
   nethermind:
     container_name: nethermind_gnosis
-    image: nethermind/nethermind:1.20.1
+    image: nethermind/nethermind:1.25.4
     restart: always
     command:
-      - --config=xdai
+      - --config=gnosis
       - --datadir=/data/nethermind
       - --Sync.FastSync=true
       - --JsonRpc.Enabled=true


### PR DESCRIPTION
In Gnosis deploy, bump Nethermind to Dencun compatible.

xdai.cfg is deprecated and gnosis.cfg is the name of the current config file